### PR TITLE
Location reading interval

### DIFF
--- a/ios-location-listener/Classes/LocationUtility.swift
+++ b/ios-location-listener/Classes/LocationUtility.swift
@@ -1,0 +1,45 @@
+//
+//  LocationUtility.swift
+//  LocationListener
+//
+//  Created by Kuama on 21/05/21.
+//
+
+import Foundation
+import CoreLocation
+
+/// Class that provides a static method to calculate a point from a given location and a converter between degrees and radians
+class LocationUtility {
+    
+    /// Calculate a new point centered 150 meters from location and with angle bearing from location using Haversine inverted formula
+    static func getCheckPointsLocation(location:CLLocation, bearing: Double)->CLLocation{
+        // data
+        let earthRadius = 6371e3 // in meters
+        let distance = 150.0 // in meters
+        let angularDistance = distance/earthRadius
+        let startingLatitude = deg2rad(location.coordinate.latitude)
+        let startingLongitude = deg2rad(location.coordinate.longitude)
+        let mBearings = deg2rad(bearing)
+        
+        // new latitude
+        var newLat = asin(sin(startingLatitude)*cos(angularDistance) +
+                            cos(startingLatitude)*sin(angularDistance)*cos(mBearings))
+        newLat = Double(round(rad2deg(newLat)*10e8)/10e8)
+        // new longitude
+        var newLon = startingLongitude + atan2(sin(mBearings)*sin(angularDistance)*cos(startingLatitude),
+                                               cos(angularDistance)-sin(startingLatitude)*sin(newLat))
+        newLon = Double(round(rad2deg(newLon)*10e8)/10e8)
+        return CLLocation(latitude: newLat, longitude: newLon)
+    }
+    
+    /// convert degrees to radians
+    static func deg2rad(_ number: Double) -> Double {
+        return number * .pi / 180
+    }
+
+    /// convert radians to degrees
+    static func rad2deg(_ number: Double) -> Double {
+        return number * 180 / .pi
+    }
+}
+

--- a/ios-location-listener/Classes/StreamLocation.swift
+++ b/ios-location-listener/Classes/StreamLocation.swift
@@ -137,6 +137,10 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
           
             var regions = Set<CLCircularRegion>()
 
+            // region centered in the current position
+            let mRegion = createRegion(location: location, radius: minRadius, id: identifier)
+            regions.update(with: mRegion)
+            
             // region in front of the current position
             let nBearing = location.course
             let nLocation = getCheckPointsLocation(location: location, bearing: nBearing)

--- a/ios-location-listener/Classes/StreamLocation.swift
+++ b/ios-location-listener/Classes/StreamLocation.swift
@@ -106,7 +106,7 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
         } else {
             CLLocationManager.scheduleLocalNotification(manager)(alert: "Last position lat:\(circRegion.center.latitude) long: \(circRegion.center.longitude)")
         }
-        removeMonitoredRegions()
+        locationManager.stopMonitoring(for: region)
         locationManager.startUpdatingLocation()
     }
     
@@ -120,10 +120,11 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
         } else {
             CLLocationManager.scheduleLocalNotification(manager)(alert: "Last position lat:\(circRegion.center.latitude) long: \(circRegion.center.longitude)")
         }
-        removeMonitoredRegions()
+        locationManager.stopMonitoring(for: region)
         locationManager.startUpdatingLocation()
     }
     
+    /// Inherited from the CLLocationManagerDelegate. This method is called when there is an update of location.
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print(error.localizedDescription)
     }
@@ -148,19 +149,19 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
             
             // region in front of the current position
             let nBearing = location.course
-            let nLocation = getCheckPointsLocation(location: location, bearing: nBearing)
+            let nLocation = LocationUtility.getCheckPointsLocation(location: location, bearing: nBearing)
             let nRegion = createRegion(location: nLocation, radius: minRadius, id: "n" + identifier)
             regions.update(with: nRegion)
             
             // region on the right of the current position
             let eBearing = location.course + 90
-            let eLocation = getCheckPointsLocation(location: location, bearing: eBearing)
+            let eLocation = LocationUtility.getCheckPointsLocation(location: location, bearing: eBearing)
             let eRegion = createRegion(location: eLocation, radius: minRadius, id: "e" + identifier)
             regions.update(with: eRegion)
 
             // region on the left of the current position
             let wBearing = location.course - 90
-            let wLocation = getCheckPointsLocation(location: location, bearing: wBearing)
+            let wLocation = LocationUtility.getCheckPointsLocation(location: location, bearing: wBearing)
             let wRegion = createRegion(location: wLocation, radius: minRadius, id: "w" + identifier)
             regions.update(with: wRegion)
 
@@ -189,35 +190,6 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
             locationManager.stopMonitoring(for: region)
         }
     }
-    
-    /// Calculate a new point centered 150 meters from location and with angle bearing from location using Haversine inverted formula
-    private func getCheckPointsLocation(location:CLLocation, bearing: Double)->CLLocation{
-        // data
-        let earthRadius = 6371e3 // in meters
-        let distance = 150.0 // in meters
-        let angularDistance = distance/earthRadius
-        let startingLatitude = deg2rad(location.coordinate.latitude)
-        let startingLongitude = deg2rad(location.coordinate.longitude)
-        let mBearings = deg2rad(bearing)
-        
-        // new latitude
-        var newLat = asin(sin(startingLatitude)*cos(angularDistance) +
-                            cos(startingLatitude)*sin(angularDistance)*cos(mBearings))
-        newLat = Double(round(rad2deg(newLat)*10e8)/10e8)
-        // new longitude
-        var newLon = startingLongitude + atan2(sin(mBearings)*sin(angularDistance)*cos(startingLatitude),
-                                               cos(angularDistance)-sin(startingLatitude)*sin(newLat))
-        newLon = Double(round(rad2deg(newLon)*10e8)/10e8)
-        return CLLocation(latitude: newLat, longitude: newLon)
-    }
-    
-    /// convert degrees to radians
-    private func deg2rad(_ number: Double) -> Double {
-        return number * .pi / 180
-    }
 
-    /// convert radians to degrees
-    func rad2deg(_ number: Double) -> Double {
-        return number * 180 / .pi
-    }}
+}
 

--- a/ios-location-listener/Classes/StreamLocation.swift
+++ b/ios-location-listener/Classes/StreamLocation.swift
@@ -60,6 +60,7 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
      It starts to update locations
      */
     public func startUpdatingLocations(){
+        locationManager.startMonitoringSignificantLocationChanges()
         locationManager.startUpdatingLocation()
     }
     
@@ -121,6 +122,10 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
         }
         removeMonitoredRegions()
         locationManager.startUpdatingLocation()
+    }
+    
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print(error.localizedDescription)
     }
     
     /// If set, it changes the alert message that will be displayed in the alert

--- a/ios-location-listener/Classes/StreamLocation.swift
+++ b/ios-location-listener/Classes/StreamLocation.swift
@@ -11,23 +11,38 @@ import CoreLocation
 import Combine
 
 /// Enum for the accuracy of the location updates
-enum Accuracy {
+public enum Accuracy {
     case foot
     case car
     case bike
 }
 
-/// This class implements both UNUserNotificationCenterDelegate and  CLLocationManagerDelegate protocols.
-/// It manages to read a stream of location both in foreground and background.
-/// When the app gets killed or suspended it reads the location every 60 seconds minimum.
-class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationManagerDelegate {
+
+/**
+ This class registers the location of the user, even when the app is terminated.
+ 
+ This class reads the location of the user and shares it through Combine's PassthroughSubject.
+ Once the location is started, It is possible to receive the updates calling the sink method on the subject.
+ It implements both UNUserNotificationCenterDelegate and  CLLocationManagerDelegate protocols.
+ When the app gets killed or suspended it reads the location every 60 seconds minimum.
+ 
+ # Example: #
+ let streamLocation = StreamLocation()
+ var cancellable: AnyCancellable? = nil
+ stream.startUpdatingLocations()
+ DispatchQueue.main.async{
+     self.cancellable = stream.subject.publisher.sink{ location in
+      ...   }
+ */
+public class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationManagerDelegate {
     
     public let subject = PassthroughSubject<CLLocation, Never>()
     private var notificationBody: String = ""
     private var notificationTitle: String = "Location Update"
     private let requestIdentifier = UUID.init().uuidString
-    private var notificationTimeInterval = 60.0
+    private var notificationTimeInterval = 60.0 // default value in seconds
     private let locationManager = CLLocationManager()
+    private let minimumTimeInterval = 60.0 // in seconds
     
     
     override init() {
@@ -36,7 +51,16 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         self.setupLocationManager()
     }
 
-    /// It sets up the location manager
+    /**
+     This method setups the location manager.
+
+     This method sets the delegate for the location manager, the accuracy, the distance filter, 
+     grants the location updates when the app is in background, sets the activity type,
+     requests permission for always reading the location and calls checkLocationAuthorization().
+ 
+     # Notes: #
+     1. This method is automatically called when a new StreamLocation object is created.
+     */
     private func setupLocationManager(){
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
@@ -50,18 +74,72 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         }
     }
     
-    /// Checks if we have the authorizations for retrieving the location
+    /**
+    This method checks if there are the authorizations to read the location and returns.
+ 
+    This method checks if the locations services are enabled and if it's possible to monitor the location.
+
+     - returns:
+        - True if the location services are enabled and if it's possible to monitor location changes.
+        
+     # Notes: #
+     1.Both location services and permission to monitor location changes must be granted.
+     */
     private func checkLocationAuthorization() -> Bool{
         return CLLocationManager.locationServicesEnabled() && CLLocationManager.significantLocationChangeMonitoringAvailable()
     }
     
-    /// Set the title and/or the body of the notification.
+    /**
+    This method sets the title and/or the text of the notification.
+ 
+    This method takes a value for the title and a value for the body content for the notification.
+ 
+    - parameters:
+        -title: The title you want to display in the notification.
+        -body: The text content you want to display inside the notification.
+ 
+     # Notes: #
+     1.Parameters must be **String** type.
+     2.Both parameters are optional. If one is set to nil, the default value is set.
+     3.The default values are:
+        \`\`\`
+        title = "Location Update"
+        body = ""
+        \`\`\`
+     4. This method must be called **before** invoking startUpdatingLocations()
+            
+
+     # Example: #
+ 
+         \`\`\`
+         let streamLocation = StreamLocation()
+        streamLocation.setNotificationContent(title:"My First Alert", body: nil)
+         \`\`\`
+     */
     public func setNotificationContent(title: String?, body: String?){
         notificationTitle = title ?? notificationTitle
         notificationBody = body ?? notificationBody
     }
     
-    /// Set the accuracy for the locations updates.
+    /**
+     This method sets the accuracy for the location updates.
+     
+     This method takes a value for accuracy and set the correspondant value for the location updates.
+     
+     - parameters
+        -accuracy: The accuracy you expect from the location updates.
+
+     # Notes: #
+     1.Parameter must be a **Accuracy** type.
+     2. If this method is not called, the accuracy is by default set to Accuracy.foot.
+ 
+     # Example: #
+     
+     \`\`\`
+         let streamLocation = StreamLocation()
+         streamLocation.setAccuracy(Accuracy.foot)
+     \`\`\`
+     */
     public func setAccuracy(accuracy: Accuracy){
         switch accuracy {
         case .bike, .foot:
@@ -71,16 +149,44 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         }
     }
     
-    /// It sets the notifications time interval. If it is less than 60 seconds, it will be set to 60 seconds.
+    /**
+     This method sets the time interval between each notification.
+ 
+     This method sets the time interval between each notification
+     that appears when the app goes in background or is terminated.
+     
+     - parameters
+        -timeInterval: a Double value in seconds that will pass between two notifications.
+        
+    # Notes: #
+     1.Parameter must be **Double** type.
+     2.Parameter can't be less than 60.0 seconds.
+     3.If the parameter is set less than 60.0 seconds, it is automatically set to 60.0.
+     
+     # Example: #
+     \`\`\`
+     let streamLocation = StreamLocation()
+     streamLocation.setNotificationTimeInterval(timeInterval: 90.0)
+     \`\`\`
+     */
     public func setNotificationTimeInterval(timeInterval: Double){
-        if timeInterval < 60.0 {
-            notificationTimeInterval = 60.0
+        if timeInterval < minimumTimeInterval {
+            notificationTimeInterval = minimumTimeInterval
         } else {
             notificationTimeInterval = timeInterval
         }
     }
     
-    /// It requests the authorizations for displaying the notifications and schedule to launch a new notification
+    /**
+    This method requests the authorizations to schedule the launch of a new notifications.
+     
+    This method asks for the authorizations to display notifications and it schedule the launch of a new notification.
+     
+     # Notes:#
+    It is possible to customize the notification using the methods:
+        *setNotificationTimeInterval: to modify the time interval between each notification. The default value is 60.0 seconds.
+        *setNotificationContent: to change the title and the text content of the notification
+     */
     func registerNotifications() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { (granted:Bool, error:Error?) in
             if error != nil { return }
@@ -93,7 +199,11 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         locationManager.requestLocation()
     }
     
-    /// Method overriden from the NotificationCenterDelegate, it is called before a notification will appear
+    /**
+     This method is called before a notification appears.
+     
+     This method ovverrides from the NotificationCenterDelegate protocol. This method is automatically called before the notification appears on the screen. When this method is invoked, it requests for a new location update and it sends it to the stream.
+     */
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         locationManager.requestLocation()
         if let location = locationManager.location {
@@ -107,7 +217,23 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         })
     }
 
-    /// It plans to launch a notification
+    /**
+     This method sets the trigger that will launch a notification.
+     
+     This method prepares a trigger that will launch a new notification. The notification can be customized with parametres passed.
+    
+    - parameters
+        - notificationTitle: the string value for the title of the notification
+        - notificationBody: the string value for the text content of the notification
+        - timeInterval: the double value in seconds that will pass before a new notification will appear
+        - repeats: the boolean value that will enable the repetition of the notification
+ 
+    # Notes:#
+    1.notificationTitle must be **String** type.
+    2.notificationBody must be **String** type.
+    3.timeInterval must be **Double** type.
+    4.repeats must be **Bool** type.
+     */
     func showNotification(notificationTitle: String, notificationBody: String, timeInterval: Double, repeats: Bool) {
         let content = UNMutableNotificationContent()
         let requestIdentifier = UUID.init().uuidString
@@ -126,26 +252,77 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         
     }
     
-    /// Remove all the notifications, both pending and delivered
+    /**
+    This method removes both pending and delivered notifications.
+    
+    This method removes all the notifications, both pending (planned) and delivered.
+     
+     #Notes: #
+    1. This method is called within stopUpdates
+     */
     func removeLocalNotifications(){
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.removeAllPendingNotificationRequests()
         notificationCenter.removeAllDeliveredNotifications()
     }
 
-    /// Start updating locations
+    /**
+     This method starts to register the location of the user.
+     
+     When this method is invoked, it starts to read the location of the user and register a notification that will start to appear when the app goes in background.
+     
+     #Notes: #
+     1. If you want to customize the notification appearance (title, content, timeInterval), you should do it before calling this method.
+     
+     #Example: #
+     \`\`\`
+        let streamLocation = StreamLocation()
+        streamLocation.startUpdatingLocations()
+     \`\`\`
+     */
     public func startUpdatingLocations(){
         registerNotifications()
         locationManager.startMonitoringSignificantLocationChanges()
         locationManager.startUpdatingLocation()
     }
     
-    /// Stop updating locations
+    /**
+     This method stops to register the location of the user.
+     
+     When this method is invoked, it stops to read the location of the user when the app is foreground or in the background. To stop the updates also when the app is terminated, you should call stopUpdates.
+ 
+     #Notes: #
+     This method stops to read the location only when the app is in foreground or in the background, **not** when the app is terminated.
+     
+     #Example: #
+     \`\`\`
+        let streamLocation = StreamLocation()
+        streamLocation.startUpdatingLocations()
+        ...
+        streamLocation.stopUpdatingLocations()
+     \`\`\`
+     */
     public func stopUpdatingLocations(){
         locationManager.stopUpdatingLocation()
     }
     
-    /// Stop both locations and notifications updates
+    /**
+     This method stops to register the location of the user and to update the notifications.
+     
+     This method stops to register the location of the user when it is in foreground, background and terminated. It also removes all the notifications, both pending and delivered.
+     
+     #Notes: #
+     1.This method completely stops the updates both of notification and location updates.
+     2.This method **must** be invoked when the app should stop, otherwise it will continue to update locations and notifications.
+     
+     #Example: #
+     \`\`\`
+        let streamLocation = StreamLocation()
+        streamLocation.startUpdatingLocations()
+        ...
+        streamLocation.stopUpdates()
+    \`\`\`
+     */
     public func stopUpdates(){
         stopUpdatingLocations()
         locationManager.stopMonitoringSignificantLocationChanges()
@@ -154,14 +331,26 @@ class StreamLocation: NSObject, UNUserNotificationCenterDelegate, CLLocationMana
         notificationCenter.removeAllPendingNotificationRequests()
     }
     
-    /// When it receives a new locations, it send it through the subject
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    /**
+    This method is called when a new location is available.
+     
+     This method is inherited from the CLLocationManagerDelegate protocol and it is automatically called when a new location is available. If there is a new location, this method publishes it in the stream.
+     
+     #Notes: #
+     This method shouldn't be invoked, it is automatically called by iOS.
+     */
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let mLocation = locations.last {
             subject.send(mLocation)
         }
     }
     
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    /**
+     This method is called when an error is thrown during the reading of the location.
+     
+     This method is inherited from the CLLocationManagerDelegate protocol and it is automatically called when the locationManager fails.
+     */
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print(error.localizedDescription)
     }
     

--- a/ios-location-listener/Classes/StreamLocation.swift
+++ b/ios-location-listener/Classes/StreamLocation.swift
@@ -20,7 +20,7 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
     private let locationManager = CLLocationManager()
     
     private var alertString: String?
-    private let minRadius = 1.0 // min radius for creating a new region
+    private let minRadius = 100.0 // min radius for creating a new region
     private let identifier = "Location Stream"
     
     /**
@@ -39,6 +39,7 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
         locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.activityType = CLActivityType.other
         locationManager.requestWhenInUseAuthorization()
         locationManager.requestAlwaysAuthorization()
         if(!checkAuthorization()){
@@ -72,14 +73,13 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
     /**
      It stops the updates of locations and the monitoring of regions. The monitoring keeps alive the app even if it is closed
      */
-    public func stopUpdates(){
+    func stopUpdates(){
         stopUpdatingLocations()
-        let monitoredRegions = locationManager.monitoredRegions
-        if(!monitoredRegions.isEmpty){
-            for region in monitoredRegions {
-                locationManager.stopMonitoring(for: region)
-            }
-        }
+        removeMonitoredRegions()
+        locationManager.stopMonitoringSignificantLocationChanges()
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.removeAllDeliveredNotifications()
+        notificationCenter.removeAllPendingNotificationRequests()
     }
     
     /**
@@ -90,7 +90,7 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
             
             subject?.send(location)
             if(!(UIApplication.shared.applicationState == .active)){
-                self.createRegion(location: location)
+                self.createMonitoredRegions(location: mLocation)
             }
         }
     }
@@ -105,26 +105,110 @@ public class StreamLocation: NSObject, CLLocationManagerDelegate{
         } else {
             CLLocationManager.scheduleLocalNotification(manager)(alert: "Last position lat:\(circRegion.center.latitude) long: \(circRegion.center.longitude)")
         }
-        locationManager.stopMonitoring(for: region)
+        removeMonitoredRegions()
         locationManager.startUpdatingLocation()
     }
     
+    /**
+     Inherited from the CLLocationManagerDelegate.  This method is called when the user enters in a region. If the app was terminated, the call to scheduleLocalNotification reactivates the app to restart the location updates.
+     */
+    public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        let circRegion = region as! CLCircularRegion
+        if(alertString != nil){
+            CLLocationManager.scheduleLocalNotification(manager)(alert: alertString!)
+        } else {
+            CLLocationManager.scheduleLocalNotification(manager)(alert: "Last position lat:\(circRegion.center.latitude) long: \(circRegion.center.longitude)")
+        }
+        removeMonitoredRegions()
+        locationManager.startUpdatingLocation()
+    }
+    
+    /// If set, it changes the alert message that will be displayed in the alert
     public func setAlertMessage(string: String){
         alertString = string
+    }
+    
+    /*
+     It creates three new regions in front, at the right and at the left of the current position
+     based on the direction in which the user is currently moving
+     */
+    func createMonitoredRegions(location: CLLocation){
+        if(CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self)){
+          
+            var regions = Set<CLCircularRegion>()
+
+            // region in front of the current position
+            let nBearing = location.course
+            let nLocation = getCheckPointsLocation(location: location, bearing: nBearing)
+            let nRegion = createRegion(location: nLocation, radius: minRadius, id: "n" + identifier)
+            regions.update(with: nRegion)
+            
+            // region on the right of the current position
+            let eBearing = location.course + 90
+            let eLocation = getCheckPointsLocation(location: location, bearing: eBearing)
+            let eRegion = createRegion(location: eLocation, radius: minRadius, id: "e" + identifier)
+            regions.update(with: eRegion)
+
+            // region on the left of the current position
+            let wBearing = location.course - 90
+            let wLocation = getCheckPointsLocation(location: location, bearing: wBearing)
+            let wRegion = createRegion(location: wLocation, radius: minRadius, id: "w" + identifier)
+            regions.update(with: wRegion)
+
+            
+            locationManager.stopUpdatingLocation()
+            for region in regions {
+                locationManager.startMonitoring(for: region)
+            }
+        }
     }
     
     /**
      This method creates a region centered in the current location and it asks to be notified when the user exits from the region. The radius of the region is set to 1mt but the minimum radius is approx. 150mt and it's decided by iOS.
      */
-    private func createRegion(location: CLLocation){
-        if(CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self)){
-            let region = CLCircularRegion(center: location.coordinate, radius: minRadius, identifier: identifier)
-            region.notifyOnExit = true
-            region.notifyOnEntry = false
-            
-            locationManager.stopUpdatingLocation()
-            locationManager.startMonitoring(for: region)
+    private func createRegion(location: CLLocation, radius: Double, id: String)-> CLCircularRegion{
+        let region = CLCircularRegion(center: location.coordinate, radius: minRadius, identifier: id)
+        region.notifyOnEntry = true
+        region.notifyOnExit = true
+        return region
+    }
+    
+    /// It removes all monitored regions
+    private func removeMonitoredRegions(){
+        let monitoredRegions = locationManager.monitoredRegions
+        for region in monitoredRegions {
+            locationManager.stopMonitoring(for: region)
         }
     }
-}
+    
+    /// Calculate a new point centered 150 meters from location and with angle bearing from location using Haversine inverted formula
+    private func getCheckPointsLocation(location:CLLocation, bearing: Double)->CLLocation{
+        // data
+        let earthRadius = 6371e3 // in meters
+        let distance = 150.0 // in meters
+        let angularDistance = distance/earthRadius
+        let startingLatitude = deg2rad(location.coordinate.latitude)
+        let startingLongitude = deg2rad(location.coordinate.longitude)
+        let mBearings = deg2rad(bearing)
+        
+        // new latitude
+        var newLat = asin(sin(startingLatitude)*cos(angularDistance) +
+                            cos(startingLatitude)*sin(angularDistance)*cos(mBearings))
+        newLat = Double(round(rad2deg(newLat)*10e8)/10e8)
+        // new longitude
+        var newLon = startingLongitude + atan2(sin(mBearings)*sin(angularDistance)*cos(startingLatitude),
+                                               cos(angularDistance)-sin(startingLatitude)*sin(newLat))
+        newLon = Double(round(rad2deg(newLon)*10e8)/10e8)
+        return CLLocation(latitude: newLat, longitude: newLon)
+    }
+    
+    /// convert degrees to radians
+    private func deg2rad(_ number: Double) -> Double {
+        return number * .pi / 180
+    }
+
+    /// convert radians to degrees
+    func rad2deg(_ number: Double) -> Double {
+        return number * 180 / .pi
+    }}
 

--- a/ios-location-listener/Classes/UserNotificationDelegate.swift
+++ b/ios-location-listener/Classes/UserNotificationDelegate.swift
@@ -26,7 +26,7 @@ extension CLLocationManager: UNUserNotificationCenterDelegate {
     }
     
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.badge, .sound])
+        completionHandler([.badge)
     }
     
     func scheduleLocalNotification(alert:String) {
@@ -38,10 +38,19 @@ extension CLLocationManager: UNUserNotificationCenterDelegate {
         content.body = alert
         
         let trigger = UNTimeIntervalNotificationTrigger.init(timeInterval: 1.0, repeats: false)
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
         let request = UNNotificationRequest(identifier: requestIdentifier, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request) { (error:Error?) in
             print("Notification Register Success")
         }
+    }
+    
+    func removeLocalNotifications(){
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.getPendingNotificationRequests(completionHandler: {
+            _ in
+            notificationCenter.removeAllPendingNotificationRequests()
+        })
     }
     
 }

--- a/ios-location-listener/Classes/UserNotificationDelegate.swift
+++ b/ios-location-listener/Classes/UserNotificationDelegate.swift
@@ -16,7 +16,7 @@ import UserNotifications
 extension CLLocationManager: UNUserNotificationCenterDelegate {
     
     func registerNotifications() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.badge,.sound]) { (granted:Bool, error:Error?) in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.badge]) { (granted:Bool, error:Error?) in
             if error != nil { return }
             DispatchQueue.main.async {
                 UIApplication.shared.registerForRemoteNotifications()
@@ -36,7 +36,6 @@ extension CLLocationManager: UNUserNotificationCenterDelegate {
         content.badge = 0
         content.title = "Location Update"
         content.body = alert
-        content.sound = UNNotificationSound.default
         
         let trigger = UNTimeIntervalNotificationTrigger.init(timeInterval: 1.0, repeats: false)
         let request = UNNotificationRequest(identifier: requestIdentifier, content: content, trigger: trigger)


### PR DESCRIPTION
Stream location now manages also the notifications that keeps to send the locations even if the app is killed. 
It is possibile to set the notification interval and it must be >=60 seconds. 
It is possible to set the accuracy and to customise the notification message content. 
The **UserNotificationDelegate.swift** and **LocationUtility.swift** files are no longer needed.